### PR TITLE
Add support for file_create()

### DIFF
--- a/lib/Net/Google/Drive/Simple.pm
+++ b/lib/Net/Google/Drive/Simple.pm
@@ -178,19 +178,7 @@ sub folder_create {
 ###########################################
     my( $self, $title, $parent ) = @_;
 
-    my $url = URI->new( $self->{ api_file_url } );
-
-    my $data = $self->http_json( $url, {
-        title    => $title,
-        parents  => [ { id => $parent } ],
-        mimeType => "application/vnd.google-apps.folder",
-    } );
-
-    if( ! defined $data ) {
-        return undef;
-    }
-
-    return $data->{ id };
+    return $self->file_create( $title, "application/vnd.google-apps.folder", $parent );
 }
 
 ###########################################

--- a/lib/Net/Google/Drive/Simple.pm
+++ b/lib/Net/Google/Drive/Simple.pm
@@ -194,6 +194,26 @@ sub folder_create {
 }
 
 ###########################################
+sub file_create {
+###########################################
+    my( $self, $title, $mime_type, $parent ) = @_;
+
+    my $url = URI->new( $self->{ api_file_url } );
+
+    my $data = $self->http_json( $url, {
+        title    => $title,
+        parents  => [ { id => $parent } ],
+        mimeType => $mime_type,
+    } );
+
+    if( ! defined $data ) {
+        return undef;
+    }
+
+    return $data->{ id };
+}
+
+###########################################
 sub file_upload {
 ###########################################
     my( $self, $file, $parent_id, $file_id ) = @_;
@@ -753,6 +773,15 @@ Drive item's fields, according to the API (see C<children()>).
 
 Create a new folder as a child of the folder with the id C<$parent_id>.
 Returns the ID of the new folder or undef in case of an error.
+
+=item C<my $id = $gd-E<gt>file_create( "folder-name", "mime-type", $parent_id )>
+
+Create a new file with the given mime type as a child of the folder with the id C<$parent_id>.
+Returns the ID of the new file or undef in case of an error.
+
+Example to create an empty google spreadsheet:
+
+    my $id = $gd->file_create( "Quarter Results", "application/vnd.google-apps.spreadsheet", "root" );
 
 =item C<$gd-E<gt>file_upload( $file, $dir_id )>
 


### PR DESCRIPTION
This pull request has to patches, the first add supports for file_create() which can be used for creating empty files. This seems odd but since Google Drive is integrated with Google Docs one can create an empty Google Spreadsheet with file_create(). This is actually what I need to do at work.

The 2nd commit is less important and can be discarded. It's just that file_create() and folder_create() are the same call as far as Google Drive is concerned. A folder is just a file with a specific mime-type. So folder_create() is now implemented as file_create().
