### PR TITLE
Add a basic travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+branches:
+  except:
+    - /^issue\d+/
+    - /^gh\d+/
+language: perl
+matrix:
+   fast_finish: true
+#   allow_failures:
+#     - perl: "5.12"
+#     - perl: "5.10"
+env:
+  global:
+    - PERL_USE_UNSAFE_INC=0
+    - AUTHOR_TESTING=1
+    - AUTOMATED_TESTING=1
+    - RELEASE_TESTING=1
+perl:
+  - "5.28"
+  - "5.26"
+  - "5.24"
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"
+script:
+  - perl Makefile.PL && make test
+


### PR DESCRIPTION
Just provide a basic .travis configuration file so anyone can smoke the distribution on multiple Perl versions.

Note: Once merged you should consider enabling travis for every commits/pull request.