### PR TITLE
Remove unsafe 'use lib' from scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+branches:
+  except:
+    - /^issue\d+/
+    - /^gh\d+/
+language: perl
+matrix:
+   fast_finish: true
+#   allow_failures:
+#     - perl: "5.12"
+#     - perl: "5.10"
+env:
+  global:
+    - PERL_USE_UNSAFE_INC=0
+    - AUTHOR_TESTING=1
+    - AUTOMATED_TESTING=1
+    - RELEASE_TESTING=1
+perl:
+  - "5.28"
+  - "5.26"
+  - "5.24"
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"
+script:
+  - perl Makefile.PL && make test
+

--- a/eg/file-upload
+++ b/eg/file-upload
@@ -1,7 +1,5 @@
 #!/usr/local/bin/perl -w
 use strict;
-use FindBin qw( $Bin );
-use lib "$Bin/../lib";
 
 use Net::Google::Drive::Simple;
 use Log::Log4perl qw(:easy);

--- a/eg/google-drive-init
+++ b/eg/google-drive-init
@@ -4,7 +4,6 @@
 # Mike Schilli, 2014 (m@perlmeister.com)
 ###########################################
 use strict;
-use lib 'lib';
 
 use OAuth::Cmdline::GoogleDrive;
 use OAuth::Cmdline::Mojo;

--- a/eg/google-drive-ls
+++ b/eg/google-drive-ls
@@ -1,6 +1,5 @@
 #!/usr/local/bin/perl -w
 use strict;
-use lib 'lib';
 
 use Sysadm::Install qw(:all);
 use Net::Google::Drive::Simple;

--- a/eg/google-drive-upsync
+++ b/eg/google-drive-upsync
@@ -1,6 +1,5 @@
 #!/usr/local/bin/perl -w
 use strict;
-use lib 'lib';
 
 use Sysadm::Install qw(:all);
 use Net::Google::Drive::Simple;


### PR DESCRIPTION
    Once installed the scripts are going to
    have access to the Perl Modules via the
    default @INC setup.

    We should not attempt to load modules from
    unpredictable locations.

    Depending from where and who runs it,
    unexpected behavior could occur.

note: eg/file-upload did not really have the same issue, as it was using FindBin but there is no point of using it. All these scripts are intended to be used after the installation. During the dev cycle, you should consider adding `-Ilib` manually if needed