### PR TITLE
Escape single quotes in file and folder names

### DIFF
--- a/lib/Net/Google/Drive/Simple.pm
+++ b/lib/Net/Google/Drive/Simple.pm
@@ -441,7 +441,7 @@ sub children_by_folder_id {
     my $url = URI->new( $self->{api_file_url} );
     $opts->{'q'} = "'$folder_id' in parents";
 
-    if( $search_opts->{ title } ) {
+    if ( $search_opts->{ title } ) {
         my $title = $search_opts->{ title };
         $title =~ s|\'|\\\'|g;
         $opts->{ q } .= " AND title = '$title'";

--- a/lib/Net/Google/Drive/Simple.pm
+++ b/lib/Net/Google/Drive/Simple.pm
@@ -441,8 +441,10 @@ sub children_by_folder_id {
     my $url = URI->new( $self->{api_file_url} );
     $opts->{'q'} = "'$folder_id' in parents";
 
-    if ( $search_opts->{title} ) {
-        $opts->{'q'} .= " AND title = '$search_opts->{ title }'";    # ' fix for poor editors
+    if( $search_opts->{ title } ) {
+        my $title = $search_opts->{ title };
+        $title =~ s|\'|\\\'|g;
+        $opts->{ q } .= " AND title = '$title'";
     }
 
     my @children = ();

--- a/lib/Net/Google/Drive/Simple.pm
+++ b/lib/Net/Google/Drive/Simple.pm
@@ -441,8 +441,7 @@ sub children_by_folder_id {
     my $url = URI->new( $self->{api_file_url} );
     $opts->{'q'} = "'$folder_id' in parents";
 
-    if ( $search_opts->{ title } ) {
-        my $title = $search_opts->{ title };
+    if ( my $title = $search_opts->{ title } ) {
         $title =~ s|\'|\\\'|g;
         $opts->{ q } .= " AND title = '$title'";
     }


### PR DESCRIPTION
When searching for files within a folder a search query containing a
path enclosed in single quotes is sent to Google.  Failure to escape any
single quotes in the path will cause an error.