### PR TITLE
Adjust perl shebang

### DIFF
--- a/eg/google-drive-init
+++ b/eg/google-drive-init
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/perl
 
 ###########################################
 # google-drive-init

--- a/t/children.t
+++ b/t/children.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/perl -w
 
 use Test2::V0;
 use Test2::Tools::Explain;

--- a/t/item.t
+++ b/t/item.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/perl -w
 
 use Test2::V0;
 use Test2::Tools::Explain;


### PR DESCRIPTION
By using /usr/bin/perl ExtUtils-MakeMaker will
update the shebang to the accurate path on installation.

Otherwise this will rely on a correct PATH.