### PR TITLE
Make sure Crypt::SSLeay will not be used

### DIFF
--- a/META.json
+++ b/META.json
@@ -50,7 +50,6 @@
       },
       "runtime" : {
          "requires" : {
-            "Crypt::SSLeay" : "0.72",
             "File::MMagic" : "1.29",
             "JSON" : "2.53",
             "LWP::Protocol::https" : "6.04",
@@ -84,11 +83,11 @@
    "provides" : {
       "Net::Google::Drive::Simple" : {
          "file" : "lib/Net/Google/Drive/Simple.pm",
-         "version" : "0.21"
+         "version" : "0.22"
       },
       "Net::Google::Drive::Simple::Item" : {
          "file" : "lib/Net/Google/Drive/Simple/Item.pm",
-         "version" : "0.21"
+         "version" : "0.22"
       }
    },
    "release_status" : "stable",
@@ -103,7 +102,7 @@
          "web" : "https://github.com/mschilli/net-google-drive-simple"
       }
    },
-   "version" : "0.21",
+   "version" : "0.22",
    "x_contributors" : [
       "Andy Baugh <thomas.baugh@cpanel.net>",
       "Andy Bircumshaw <github.com@networkned.co.uk>",
@@ -116,12 +115,13 @@
       "Mohammad S Anwar <mohammad.anwar@yahoo.com>",
       "Nicolas R <atoomic@cpan.org>",
       "Peter Scott <peter@computerpros.com.au>",
+      "Sawyer X <xsawyerx@cpan.org>",
       "Tim Mullin <tim@cpanel.net>",
       "Todd Rinaldo <toddr@cpan.org>",
       "Yxes <wells@cedarnet.org>"
    ],
    "x_generated_by_perl" : "v5.32.1",
-   "x_serialization_backend" : "Cpanel::JSON::XS version 4.27",
+   "x_serialization_backend" : "Cpanel::JSON::XS version 4.26",
    "x_spdx_expression" : "Artistic-1.0-Perl OR GPL-1.0-or-later"
 }
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,6 @@ my %WriteMakefileArgs = (
   "LICENSE" => "perl",
   "NAME" => "Net::Google::Drive::Simple",
   "PREREQ_PM" => {
-    "Crypt::SSLeay" => "0.72",
     "File::MMagic" => "1.29",
     "JSON" => "2.53",
     "LWP::Protocol::https" => "6.04",
@@ -46,7 +45,6 @@ my %WriteMakefileArgs = (
 );
 
 my %FallbackPrereqs = (
-  "Crypt::SSLeay" => "0.72",
   "ExtUtils::MakeMaker" => 0,
   "File::MMagic" => "1.29",
   "File::Spec" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 
 on 'runtime' => sub {
-    requires 'Crypt::SSLeay'        => '0.72';
     requires 'File::MMagic'         => '1.29';
     requires 'JSON'                 => '2.53';
     requires 'Log::Log4perl'        => '1';


### PR DESCRIPTION
If you have both LWP::Protocol::https installed, Crypt:SSLeay will not
be used.

LWP::UserAgent loads LWP::Protocol::https if it's installed. Since
it's a dependency, it's installed. LWP::Protocol::https has a
dependency on IO::Socket::SSL, so it will be picked up instead of
Crypt::SSLeay.

I verified this with the following code in the `t/001Basic.t` test
using the `LIVE_TEST` option:

    BEGIN {
        unshift @INC, sub {
            print STDERR "Loaded $_[1]\n";
        };
    }