### PR TITLE
Fix title option search in files() method:

### DIFF
--- a/lib/Net/Google/Drive/Simple.pm
+++ b/lib/Net/Google/Drive/Simple.pm
@@ -150,6 +150,15 @@ sub files {
 
     $self->init();
 
+    if ( my $title = $search_opts->{title} ) {
+        $title =~ s|\'|\\\'|g;
+        if ( defined $opts->{q} && length $opts->{q} ) {
+            $opts->{q} .= ' AND ';
+        }
+
+        $opts->{q} .= "title = '$title'";
+    }
+
     my @docs = ();
 
     while (1) {


### PR DESCRIPTION
The `t/001Basic.t` test is failing with `LIVE_TEST=1` because it attempts to do a search using the `files()` method using a `title` parameter. This parameter isn't being added to the search options so it isn't being used.

Before:

    $ LIVE_TEST=1 perl -Ilib t/001Basic.t
    1..13
    ok 1 - loaded ok
    ok 2 - non-existent path
    ok 3 - error message
    ok 4 - children returned ok
    ok 5 - upload ok
    ok 6 - metadata ok
    ok 7 - file founds via children()
    ok 8 - Got the file, original filename looks right (via children())
    ok 9 - files found via files()
    ok 10 - Got the file, original filename looks right (via files())
    ok 11 - delete ok
    ok 12 - Can no longer find deleted file (via children())
    not ok 13 - Can no longer find deleted file (via files)
    #   Failed test 'Can no longer find deleted file (via files)'
    #   at t/001Basic.t line 67.
    # Looks like you failed 1 test of 13.

After:

    $ LIVE_TEST=1 perl -Ilib t/001Basic.t
    1..13
    ok 1 - loaded ok
    ok 2 - non-existent path
    ok 3 - error message
    ok 4 - children returned ok
    ok 5 - upload ok
    ok 6 - metadata ok
    ok 7 - file founds via children()
    ok 8 - Got the file, original filename looks right (via children())
    ok 9 - files found via files()
    ok 10 - Got the file, original filename looks right (via files())
    ok 11 - delete ok
    ok 12 - Can no longer find deleted file (via children())
    ok 13 - Can no longer find deleted file (via files)